### PR TITLE
Fetch mission and create dispatch action

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -1,0 +1,10 @@
+import axios from 'axios';
+
+const api = axios.create({
+  baseURL: 'https://api.spacexdata.com/v3/',
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
+export default api;

--- a/src/pages/Missions.jsx
+++ b/src/pages/Missions.jsx
@@ -1,3 +1,13 @@
-const MissionsPage = () => <h1>Missions Page</h1>;
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+import { getMissions } from '../redux/missions/missionsSlice';
+
+function MissionsPage() {
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(getMissions());
+  }, [dispatch]);
+}
 
 export default MissionsPage;

--- a/src/redux/missions/missionsSlice.js
+++ b/src/redux/missions/missionsSlice.js
@@ -1,10 +1,30 @@
-import { createSlice } from '@reduxjs/toolkit';
+import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
+import api from '../../api';
 
-const initialState = [];
+const FETCH = 'missions/FETCH';
+
+const initialState = {
+  missions: [],
+};
+
+export const getMissions = createAsyncThunk(FETCH, async () => {
+  const missions = await api.get('/missions');
+  return missions.data.map((mission) => ({
+    id: mission.mission_id,
+    name: mission.mission_name,
+    description: mission.description,
+  }));
+});
 
 const missionsSlice = createSlice({
   name: 'missions',
   initialState,
+  extraReducers: {
+    [getMissions.fulfilled]: (state, action) => {
+      const currState = state;
+      currState.missions = action.payload;
+    },
+  },
 });
 
 export default missionsSlice.reducer;


### PR DESCRIPTION
hello dear reviewer,
In this pull request I worked on fetching data from the Missions endpoint (https://api.spacexdata.com/v3/missions) when a user navigates to the Missions section.

Once the data are fetched, I added a dispatch an action to store the selected data in Redux store:

- mission_id
- mission_name
- description

please let me know if anything needs improvement.
Best regards