### PR TITLE
Rocket booking actions and badge

### DIFF
--- a/src/components/RocketItem.jsx
+++ b/src/components/RocketItem.jsx
@@ -1,4 +1,4 @@
-import { Button } from 'react-bootstrap';
+import { Badge, Button } from 'react-bootstrap';
 import { useDispatch } from 'react-redux';
 import { rocketReserved } from '../redux/rockets/rocketSlice';
 import RocketType from '../types/rockets';
@@ -27,10 +27,17 @@ const RocketItem = ({ rocket }) => {
         }}
       >
         <h5>{name}</h5>
-        <p>{description}</p>
+        <p>
+          {reserved && (
+            <Badge style={{ marginRight: '.75rem' }} bg="info">
+              Reserved
+            </Badge>
+          )}
+          {description}
+        </p>
         <Button
           onClick={handleClick}
-          variant="primary"
+          variant={reserved ? 'outline-secondary' : 'primary'}
           style={{ borderRadius: '.25rem' }}
         >
           {reserved ? 'Cancel Reservation' : 'Reserve Rocket'}

--- a/src/components/RocketItem.jsx
+++ b/src/components/RocketItem.jsx
@@ -1,9 +1,17 @@
-import PropTypes from 'prop-types';
 import { Button } from 'react-bootstrap';
+import { useDispatch } from 'react-redux';
+import { rocketReserved } from '../redux/rockets/rocketSlice';
 import RocketType from '../types/rockets';
 
 const RocketItem = ({ rocket }) => {
-  const { name, flickrImage, description } = rocket;
+  const {
+    id, name, flickrImage, description, reserved,
+  } = rocket;
+
+  const dispatch = useDispatch();
+  const handleClick = () => {
+    dispatch(rocketReserved(id));
+  };
 
   return (
     <li
@@ -20,8 +28,12 @@ const RocketItem = ({ rocket }) => {
       >
         <h5>{name}</h5>
         <p>{description}</p>
-        <Button variant="primary" style={{ borderRadius: '.25rem' }}>
-          Reserve Rocket
+        <Button
+          onClick={handleClick}
+          variant="primary"
+          style={{ borderRadius: '.25rem' }}
+        >
+          {reserved ? 'Cancel Reservation' : 'Reserve Rocket'}
         </Button>
       </div>
     </li>
@@ -29,7 +41,7 @@ const RocketItem = ({ rocket }) => {
 };
 
 RocketItem.propTypes = {
-  rocket: PropTypes.objectOf(RocketType).isRequired,
+  rocket: RocketType.isRequired,
 };
 
 export default RocketItem;

--- a/src/pages/Rockets.jsx
+++ b/src/pages/Rockets.jsx
@@ -1,3 +1,4 @@
+import { nanoid } from '@reduxjs/toolkit';
 import { useEffect } from 'react';
 import { Container } from 'react-bootstrap';
 import { useDispatch, useSelector } from 'react-redux';
@@ -12,11 +13,12 @@ function RocketsPage() {
   }, [dispatch]);
 
   const { rockets } = useSelector((state) => state.rockets);
+
   return (
     <Container fluid="xl">
       <ul>
-        {rockets.map(({ id, ...rocket }) => (
-          <RocketItem key={id} rocket={rocket} />
+        {rockets.map((rocket) => (
+          <RocketItem key={nanoid()} rocket={rocket} />
         ))}
       </ul>
     </Container>

--- a/src/redux/rockets/rocketSlice.js
+++ b/src/redux/rockets/rocketSlice.js
@@ -15,12 +15,27 @@ export const getRockets = createAsyncThunk(FETCH, async () => {
     type: rocket.rocket_type,
     flickrImage: rocket.flickr_images[0],
     description: rocket.description,
+    reserved: false,
   }));
 });
 
 const rocketsSlice = createSlice({
   name: 'rockets',
   initialState,
+  reducers: {
+    rocketReserved(state, action) {
+      const rockets = state.rockets.map((rocket) => {
+        if (rocket.id === action.payload) {
+          return {
+            ...rocket,
+            reserved: !rocket.reserved,
+          };
+        }
+        return rocket;
+      });
+      return { ...state, rockets };
+    },
+  },
   extraReducers: {
     [getRockets.fulfilled]: (state, action) => {
       const currState = state;
@@ -29,4 +44,5 @@ const rocketsSlice = createSlice({
   },
 });
 
+export const { rocketReserved } = rocketsSlice.actions;
 export default rocketsSlice.reducer;

--- a/src/types/rockets.js
+++ b/src/types/rockets.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 
 const RocketType = PropTypes.shape({
+  id: PropTypes.number.isRequired,
   name: PropTypes.string.isRequired,
   type: PropTypes.string.isRequired,
   flickrImage: PropTypes.string.isRequired,


### PR DESCRIPTION
Hi there :wave:

This PR implements the dispatch of actions and updates to the user interface for both the "Reserve Rocket" and "Cancel Reservation" buttons. When a user clicks either button, the store state is updated by returning a new state object with all rockets, but with the selected rocket now having the "reserved" key set to either "true" or "false" depending on the action.

Rockets that have already been reserved now show a "Reserved" badge and "Cancel Reservation" button instead of the default "Reserve Rocket" button.

Let me know if there are any additional changes needed.

Thanks!

Closes #5, Closes #8, Closes #12